### PR TITLE
Fix `client_secret is missing` error

### DIFF
--- a/web/oauth/google.ex
+++ b/web/oauth/google.ex
@@ -26,7 +26,7 @@ defmodule Google do
   end
 
   def get_token!(params \\ [], headers \\ []) do
-    OAuth2.Client.get_token!(client(), params)
+    OAuth2.Client.get_token!(client(), Keyword.merge(params, client_secret: client().client_secret))
   end
 
   # Strategy Callbacks


### PR DESCRIPTION
The `client_secret` wasn't sent so you'd get a `HTTP 401` from Google.
